### PR TITLE
fix: provide missing implementation for namespace deletion

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -126,7 +127,7 @@ func (in *AccountStatus) DeepCopyInto(out *AccountStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]v1.Condition, len(*in))
+		*out = make([]metav1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,8 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -127,7 +126,7 @@ func (in *AccountStatus) DeepCopyInto(out *AccountStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]metav1.Condition, len(*in))
+		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/subroutines/namespace.go
+++ b/pkg/subroutines/namespace.go
@@ -51,6 +51,10 @@ func (r *NamespaceSubroutine) Finalize(ctx context.Context, runtimeObj lifecycle
 		return ctrl.Result{}, errors.NewOperatorError(err, true, true)
 	}
 
+	if ns.GetDeletionTimestamp() != nil {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	err = r.client.Delete(ctx, &ns)
 	if err != nil {
 		return ctrl.Result{}, errors.NewOperatorError(err, true, true)

--- a/pkg/subroutines/namespace.go
+++ b/pkg/subroutines/namespace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +36,27 @@ func (r *NamespaceSubroutine) GetName() string {
 }
 
 func (r *NamespaceSubroutine) Finalize(ctx context.Context, runtimeObj lifecycle.RuntimeObject) (ctrl.Result, errors.OperatorError) {
-	return ctrl.Result{}, nil
+	instance := runtimeObj.(*corev1alpha1.Account)
+
+	if instance.Status.Namespace == nil {
+		return ctrl.Result{}, nil
+	}
+
+	ns := v1.Namespace{}
+	err := r.client.Get(ctx, client.ObjectKey{Name: *instance.Status.Namespace}, &ns)
+	if kerrors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		return ctrl.Result{}, errors.NewOperatorError(err, true, true)
+	}
+
+	err = r.client.Delete(ctx, &ns)
+	if err != nil {
+		return ctrl.Result{}, errors.NewOperatorError(err, true, true)
+	}
+
+	return ctrl.Result{Requeue: true}, nil // we need to requeue to check if the namespace was deleted
 }
 
 func (r *NamespaceSubroutine) Finalizers() []string { // coverage-ignore
@@ -82,12 +103,14 @@ var NamespaceOwnedByAnotherAccountErr = errors.New("Namespace already owned by a
 var NamespaceOwnedByAnAccountInAnotherNamespaceErr = errors.New("Namespace already owned by another account in another namespace")
 
 func setNamespaceLabels(ns *v1.Namespace, instance *corev1alpha1.Account) error {
-	hasOwnerLabel := hasLabel(NamespaceAccountOwnerLabel, ns.Labels)
-	hasOwnerNamespaceLabel := hasLabel(NamespaceAccountOwnerNamespaceLabel, ns.Labels)
-	if hasOwnerLabel && ns.Labels[NamespaceAccountOwnerLabel] != instance.GetName() {
+	accountOwner, hasOwnerLabel := ns.Labels[NamespaceAccountOwnerLabel]
+	accountOwnerNamespace, hasOwnerNamespaceLabel := ns.Labels[NamespaceAccountOwnerNamespaceLabel]
+
+	if hasOwnerLabel && accountOwner != instance.GetName() {
 		return NamespaceOwnedByAnotherAccountErr
 	}
-	if hasOwnerNamespaceLabel && ns.Labels[NamespaceAccountOwnerNamespaceLabel] != instance.GetNamespace() {
+
+	if hasOwnerNamespaceLabel && accountOwnerNamespace != instance.GetNamespace() {
 		return NamespaceOwnedByAnAccountInAnotherNamespaceErr
 	}
 
@@ -98,12 +121,8 @@ func setNamespaceLabels(ns *v1.Namespace, instance *corev1alpha1.Account) error 
 		ns.Labels[NamespaceAccountOwnerLabel] = instance.GetName()
 		ns.Labels[NamespaceAccountOwnerNamespaceLabel] = instance.GetNamespace()
 	}
-	return nil
-}
 
-func hasLabel(key string, labels map[string]string) bool {
-	_, ok := labels[key]
-	return ok
+	return nil
 }
 
 func generateNamespace(instance *corev1alpha1.Account) *v1.Namespace {

--- a/pkg/subroutines/namespace_test.go
+++ b/pkg/subroutines/namespace_test.go
@@ -1,4 +1,4 @@
-package subroutines
+package subroutines_test
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1alpha1 "github.com/openmfp/account-operator/api/v1alpha1"
+	"github.com/openmfp/account-operator/pkg/subroutines"
 	"github.com/openmfp/account-operator/pkg/subroutines/mocks"
 )
 
@@ -24,7 +25,7 @@ type NamespaceSubroutineTestSuite struct {
 	suite.Suite
 
 	// Tested Object(s)
-	testObj *NamespaceSubroutine
+	testObj *subroutines.NamespaceSubroutine
 
 	// Mocks
 	clientMock *mocks.Client
@@ -35,7 +36,7 @@ func (suite *NamespaceSubroutineTestSuite) SetupTest() {
 	suite.clientMock = new(mocks.Client)
 
 	// Initialize Tested Object(s)
-	suite.testObj = NewNamespaceSubroutine(suite.clientMock)
+	suite.testObj = subroutines.NewNamespaceSubroutine(suite.clientMock)
 }
 
 func (suite *NamespaceSubroutineTestSuite) TestGetName_OK() {
@@ -43,7 +44,7 @@ func (suite *NamespaceSubroutineTestSuite) TestGetName_OK() {
 	result := suite.testObj.GetName()
 
 	// Then
-	suite.Equal(NamespaceSubroutineName, result)
+	suite.Equal(subroutines.NamespaceSubroutineName, result)
 }
 
 func (suite *NamespaceSubroutineTestSuite) TestFinalize_OK() {
@@ -99,8 +100,8 @@ func (suite *NamespaceSubroutineTestSuite) TestProcessingWithNamespaceInStatus()
 		},
 	}
 	mockGetNamespaceCallWithLabels(suite, defaultExpectedTestNamespace, map[string]string{
-		NamespaceAccountOwnerLabel:          testAccount.Name,
-		NamespaceAccountOwnerNamespaceLabel: testAccount.Namespace,
+		subroutines.NamespaceAccountOwnerLabel:          testAccount.Name,
+		subroutines.NamespaceAccountOwnerNamespaceLabel: testAccount.Namespace,
 	})
 
 	// When
@@ -141,7 +142,7 @@ func (suite *NamespaceSubroutineTestSuite) TestProcessingWithNamespaceInStatusMi
 		},
 	}
 	mockGetNamespaceCallWithLabels(suite, defaultExpectedTestNamespace, map[string]string{
-		NamespaceAccountOwnerLabel: testAccount.Name,
+		subroutines.NamespaceAccountOwnerLabel: testAccount.Name,
 	})
 	mockNewNamespaceUpdateCall(suite)
 
@@ -164,7 +165,7 @@ func (suite *NamespaceSubroutineTestSuite) TestProcessingWithNamespaceInStatusMi
 		},
 	}
 	mockGetNamespaceCallWithLabels(suite, defaultExpectedTestNamespace, map[string]string{
-		NamespaceAccountOwnerLabel: testAccount.Name,
+		subroutines.NamespaceAccountOwnerLabel: testAccount.Name,
 	})
 	suite.clientMock.EXPECT().
 		Update(mock.Anything, mock.Anything).
@@ -228,8 +229,8 @@ func (suite *NamespaceSubroutineTestSuite) TestProcessingWithDeclaredNamespace_O
 		},
 	}
 	mockGetNamespaceCallWithLabels(suite, namespaceName, map[string]string{
-		NamespaceAccountOwnerLabel:          testAccount.Name,
-		NamespaceAccountOwnerNamespaceLabel: testAccount.Namespace,
+		subroutines.NamespaceAccountOwnerLabel:          testAccount.Name,
+		subroutines.NamespaceAccountOwnerNamespaceLabel: testAccount.Namespace,
 	})
 
 	// When
@@ -310,7 +311,7 @@ func (suite *NamespaceSubroutineTestSuite) TestProcessingWithDeclaredNamespaceMi
 		},
 	}
 	mockGetNamespaceCallWithLabels(suite, namespaceName, map[string]string{
-		NamespaceAccountOwnerLabel: "different-owner",
+		subroutines.NamespaceAccountOwnerLabel: "different-owner",
 	})
 
 	// When
@@ -319,6 +320,39 @@ func (suite *NamespaceSubroutineTestSuite) TestProcessingWithDeclaredNamespaceMi
 	// Then
 	suite.Require().Nil(testAccount.Status.Namespace)
 	suite.NotNil(err)
+}
+
+func (suite *NamespaceSubroutineTestSuite) TestFinalizationWithNamespaceInStatus() {
+	namespaceName := "a-names-space"
+	testAccount := &corev1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-account"},
+		Status: corev1alpha1.AccountStatus{
+			Namespace: &namespaceName,
+		},
+	}
+
+	mockGetNamespaceCallWithName(suite, namespaceName)
+	mockDeleteNamespaceCall(suite)
+
+	result, err := suite.testObj.Finalize(context.Background(), testAccount)
+	suite.Require().Nil(err)
+	suite.Require().True(result.Requeue)
+}
+
+func (suite *NamespaceSubroutineTestSuite) TestFinalizationWithNamespaceInStatus_NamespaceGone() {
+	namespaceName := "a-names-space"
+	testAccount := &corev1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-account"},
+		Status: corev1alpha1.AccountStatus{
+			Namespace: &namespaceName,
+		},
+	}
+
+	mockGetNamespaceCallNotFound(suite)
+
+	result, err := suite.testObj.Finalize(context.Background(), testAccount)
+	suite.Require().Nil(err)
+	suite.Require().False(result.Requeue)
 }
 
 func TestNamespaceSubroutineTestSuite(t *testing.T) {
@@ -352,6 +386,24 @@ func mockGetNamespaceCallWithLabels(suite *NamespaceSubroutineTestSuite, name st
 			actual.Name = name
 			actual.Labels = labels
 		}).
+		Return(nil)
+}
+
+//nolint:golint,unparam
+func mockGetNamespaceCallWithName(suite *NamespaceSubroutineTestSuite, name string) *mocks.Client_Get_Call {
+	return suite.clientMock.EXPECT().
+		Get(mock.Anything, mock.Anything, mock.Anything).
+		Run(func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) {
+			actual, _ := obj.(*v1.Namespace)
+			actual.Name = name
+		}).
+		Return(nil)
+}
+
+//nolint:golint,unparam
+func mockDeleteNamespaceCall(suite *NamespaceSubroutineTestSuite) *mocks.Client_Delete_Call {
+	return suite.clientMock.EXPECT().
+		Delete(mock.Anything, mock.Anything).
 		Return(nil)
 }
 


### PR DESCRIPTION
This PR adds the missing implementation of the `Finalize()` method to properly clean up the created namespace of the account.