### PR TITLE
feat: store lookup on kcp

### DIFF
--- a/internal/controller/account_controller.go
+++ b/internal/controller/account_controller.go
@@ -70,9 +70,9 @@ func NewAccountReconciler(log *logger.Logger, mgr ctrl.Manager, cfg config.Confi
 
 		srv := service.NewService(mgr.GetClient(), cfg.Subroutines.FGA.RootNamespace)
 
-		cl := openfgav1.NewOpenFGAServiceClient(conn)
+		fgaClient := openfgav1.NewOpenFGAServiceClient(conn)
 
-		subs = append(subs, subroutines.NewFGASubroutine(cl, srv, cfg.Subroutines.FGA.RootNamespace, cfg.Subroutines.FGA.CreatorRelation, cfg.Subroutines.FGA.ParentRelation, cfg.Subroutines.FGA.ObjectType))
+		subs = append(subs, subroutines.NewFGASubroutine(mgr.GetClient(), fgaClient, srv, cfg.Subroutines.FGA.RootNamespace, cfg.Subroutines.FGA.CreatorRelation, cfg.Subroutines.FGA.ParentRelation, cfg.Subroutines.FGA.ObjectType))
 	}
 	return &AccountReconciler{
 		lifecycle: lifecycle.NewLifecycleManager(log, operatorName, accountReconcilerName, mgr.GetClient(), subs).WithSpreadingReconciles().WithConditionManagement(),

--- a/pkg/subroutines/extensions.go
+++ b/pkg/subroutines/extensions.go
@@ -122,7 +122,10 @@ func RenderExtensionSpec(ctx context.Context, keyValues map[string]any, account 
 				return err
 			}
 		case map[string]any:
-			return RenderExtensionSpec(ctx, val, account, us, append(path, key))
+			err := RenderExtensionSpec(ctx, val, account, us, append(path, key))
+			if err != nil {
+				return err
+			}
 		default: // any other primitive type
 			err := unstructured.SetNestedField(us.Object, val, append(path, key)...)
 			if err != nil {

--- a/pkg/subroutines/extensions.go
+++ b/pkg/subroutines/extensions.go
@@ -207,12 +207,8 @@ func getParentAccount(ctx context.Context, cl client.Client, ns string) (*v1alph
 func getParentAccountWithKcp(ctx context.Context, cl client.Client) (*v1alpha1.Account, *string, error) {
 
 	cluster, ok := kontext.ClusterFrom(ctx)
-	if !ok {
+	if !ok || cluster.Empty() {
 		return nil, nil, fmt.Errorf("no cluster context found, this is a configuration error")
-	}
-
-	if cluster.Empty() {
-		return nil, nil, fmt.Errorf("no cluster in context is empty")
 	}
 
 	wsCtx := kontext.WithCluster(ctx, "")


### PR DESCRIPTION
This PR improves how the operator determines the parent account, especially when using KCP.

It also fixes an issue discovered regarding templating on account extensions that lead to not completely templated resources