### PR TITLE
feat: support for accountInfo in fga subroutine

### DIFF
--- a/pkg/subroutines/fga.go
+++ b/pkg/subroutines/fga.go
@@ -91,6 +91,12 @@ func (e *FGASubroutine) Process(ctx context.Context, runtimeObj lifecycle.Runtim
 			Relation: e.parentRelation,
 			User:     fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.ParentAccount.OriginClusterId, parentAccountName),
 		})
+		// Write tuple for accountinfo parent relation to account
+		writes = append(writes, &openfgav1.TupleKey{
+			Object:   fmt.Sprintf("accountinfo:%s/%s", accountInfo.Spec.Account.OriginClusterId, account.GetName()),
+			Relation: "parent",
+			User:     fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.Account.OriginClusterId, account.GetName()),
+		})
 	}
 
 	// Assign creator to the account
@@ -162,6 +168,13 @@ func (e *FGASubroutine) Finalize(ctx context.Context, runtimeObj lifecycle.Runti
 				User:     fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.Account.OriginClusterId, parentAccountName),
 				Relation: e.parentRelation,
 				Object:   fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.Account.GeneratedClusterId, account.GetName()),
+			})
+
+			// Add deletion for the accountinfo parent relation tuple
+			deletes = append(deletes, &openfgav1.TupleKeyWithoutCondition{
+				Object:   fmt.Sprintf("accountinfo:%s/%s", accountInfo.Spec.Account.OriginClusterId, account.GetName()),
+				Relation: "parent",
+				User:     fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.Account.OriginClusterId, account.GetName()),
 			})
 		}
 

--- a/pkg/subroutines/fga.go
+++ b/pkg/subroutines/fga.go
@@ -162,12 +162,12 @@ func (e *FGASubroutine) Finalize(ctx context.Context, runtimeObj lifecycle.Runti
 
 		deletes := []*openfgav1.TupleKeyWithoutCondition{}
 		if account.Spec.Type != v1alpha1.AccountTypeOrg {
-			parentAccountName := accountInfo.Spec.Account.Name
+			parentAccountName := accountInfo.Spec.ParentAccount.Name
 
 			deletes = append(deletes, &openfgav1.TupleKeyWithoutCondition{
-				User:     fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.Account.OriginClusterId, parentAccountName),
+				User:     fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.ParentAccount.OriginClusterId, parentAccountName),
 				Relation: e.parentRelation,
-				Object:   fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.Account.GeneratedClusterId, account.GetName()),
+				Object:   fmt.Sprintf("%s:%s/%s", e.objectType, accountInfo.Spec.Account.OriginClusterId, account.GetName()),
 			})
 
 			// Add deletion for the accountinfo parent relation tuple


### PR DESCRIPTION
#263 

- updated the fga-operator chart to extend the coreModule (https://github.com/openmfp/helm-charts-priv/pull/1494)
- updated the fga subroutine to write the accountinfo tuple with parent relation to the account
- updated the fga test to cover new accountinfo tuple

**Testing**:
`task test`
`test ./internal/controller/account_controller_test.go -v`